### PR TITLE
Create and Fetch Secrets

### DIFF
--- a/cmd/whisper/main.go
+++ b/cmd/whisper/main.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"math/big"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/joho/godotenv"
 	whisper "github.com/rotationalio/whisper/pkg"
@@ -43,6 +51,70 @@ func main() {
 					Aliases: []string{"a"},
 					Usage:   "address to bind the whisper server on",
 					EnvVars: []string{"WHISPER_BIND_ADDR"},
+				},
+			},
+		},
+		{
+			Name:     "create",
+			Usage:    "create a whisper secret",
+			Category: "client",
+			Before:   initClient,
+			Action:   create,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "secret",
+					Aliases: []string{"s"},
+					Usage:   "input the secret as a string on the command line",
+				},
+				&cli.IntFlag{
+					Name:    "generate",
+					Aliases: []string{"g"},
+					Usage:   "generate a random secret of the specified length",
+				},
+				&cli.StringFlag{
+					Name:    "in",
+					Aliases: []string{"i", "u", "upload"},
+					Usage:   "upload a file as the secret contents",
+				},
+				&cli.StringFlag{
+					Name:    "password",
+					Aliases: []string{"p"},
+					Usage:   "specify a password to access the secret",
+				},
+				&cli.IntFlag{
+					Name:    "generate-password",
+					Aliases: []string{"G", "gp"},
+					Usage:   "generate a random password of the specified length",
+				},
+				&cli.DurationFlag{
+					Name:    "lifetime",
+					Aliases: []string{"l", "e", "expires", "expires-after"},
+					Usage:   "specify the lifetime of the secret before it is deleted",
+				},
+				&cli.BoolFlag{
+					Name:    "b64encoded",
+					Aliases: []string{"b", "b64"},
+					Usage:   "specify if the secret is base64 encoded (true if uploading a file, false if generated)",
+				},
+			},
+		},
+		{
+			Name:      "fetch",
+			Usage:     "fetch a whisper secret by its token",
+			ArgsUsage: "token",
+			Category:  "client",
+			Before:    initClient,
+			Action:    fetch,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "password",
+					Aliases: []string{"p"},
+					Usage:   "specify a password to access the secret",
+				},
+				&cli.StringFlag{
+					Name:    "out",
+					Aliases: []string{"o", "d", "download"},
+					Usage:   "download the secret to a file or to a directory",
 				},
 			},
 		},
@@ -93,9 +165,145 @@ func serve(c *cli.Context) (err error) {
 
 var client v1.Service
 
+func create(c *cli.Context) (err error) {
+	// Create the request
+	req := &v1.CreateSecretRequest{
+		Password: c.String("password"),
+		Lifetime: v1.Duration(c.Duration("lifetime")),
+	}
+
+	// Add the secret to the request via one of the command line options
+	switch {
+	case c.String("secret") != "":
+		if c.Int("generate") != 0 || c.String("in") != "" {
+			return cli.Exit("specify only one of secret, generate, or in path", 1)
+		}
+
+		// Basic secret provided via the CLI
+		req.Secret = c.String("secret")
+		req.IsBase64 = c.Bool("b64encoded")
+
+	case c.String("in") != "":
+		if c.Int("generate") != 0 {
+			// The check for secret has already been done
+			return cli.Exit("specify only one of secret, generate, or in path", 1)
+		}
+
+		// Load the secret as base64 encoded data from a file
+		var data []byte
+		if data, err = ioutil.ReadFile(c.String("in")); err != nil {
+			return cli.Exit(err, 1)
+		}
+		req.Filename = filepath.Base(c.String("in"))
+		req.Secret = base64.StdEncoding.EncodeToString(data)
+		req.IsBase64 = true
+
+	case c.Int("generate") != 0:
+		// Generate a random secret of the specified length
+		if req.Secret, err = generateRandomSecret(c.Int("generate")); err != nil {
+			return cli.Exit(err, 1)
+		}
+		req.IsBase64 = false
+
+	default:
+		// No secret was specified at all?
+		return cli.Exit("specify at least one of secret, generate, or in path", 1)
+	}
+
+	// Handle password generation if requested
+	if gp := c.Int("generate-password"); gp > 0 {
+		if req.Password != "" {
+			return cli.Exit("specify either password or generate password, not both", 1)
+		}
+		if req.Password, err = generateRandomSecret(gp); err != nil {
+			return cli.Exit(err, 1)
+		}
+		// Print the password so that it can be used to retrieve the secret later
+		fmt.Printf("Password for retrieval: %s\n", req.Password)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *v1.CreateSecretReply
+	if rep, err = client.CreateSecret(ctx, req); err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	return printJSON(rep)
+}
+
+func fetch(c *cli.Context) (err error) {
+	if c.NArg() != 1 {
+		return cli.Exit("specify one token to fetch the secret for", 1)
+	}
+
+	token := c.Args().First()
+	req := &v1.FetchSecretRequest{
+		Password: c.String("password"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var rep *v1.FetchSecretReply
+	if rep, err = client.FetchSecret(ctx, token, req); err != nil {
+		return cli.Exit(err, 1)
+	}
+
+	// Figure out where to write the file to; if out is a directory, write the
+	var path string
+
+	// If the user has specified an output location, handle it.
+	if out := c.String("out"); out != "" {
+		var isDir bool
+		if isDir, err = isDirectory(out); err == nil && isDir {
+			if rep.Filename != "" {
+				path = filepath.Join(out, rep.Filename)
+			} else {
+				path = filepath.Join(out, "secret.dat")
+			}
+		} else {
+			path = out
+		}
+	} else {
+		// If the user didn't specify an out location and the response has a filename,
+		// write the file with the specified filename in the current working directory.
+		path = rep.Filename
+	}
+
+	// If we've discovered a path to write the file to, write it there, decoding the
+	// data as necessary from base64. Otherwise print the json to stdout and exit.
+	if path != "" {
+		fmt.Println(path)
+		var data []byte
+		if rep.IsBase64 {
+			if data, err = base64.StdEncoding.DecodeString(rep.Secret); err != nil {
+				return cli.Exit(err, 1)
+			}
+		} else {
+			data = []byte(rep.Secret)
+		}
+
+		if err = ioutil.WriteFile(path, data, 0644); err != nil {
+			return cli.Exit(err, 1)
+		}
+
+		fmt.Printf("secret written to %s\n", path)
+		return nil
+	}
+
+	// Simply print the JSON response as the last case.
+	// TODO: should we provide a flag to just print the secret for copy and paste?
+	return printJSON(rep)
+}
+
 func status(c *cli.Context) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	var rep *v1.StatusReply
-	if rep, err = client.Status(); err != nil {
+	if rep, err = client.Status(ctx); err != nil {
 		return cli.Exit(err, 1)
 	}
 	return printJSON(rep)
@@ -110,6 +318,28 @@ func initClient(c *cli.Context) (err error) {
 		return cli.Exit(err, 1)
 	}
 	return nil
+}
+
+func generateRandomSecret(n int) (s string, err error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_%=+"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+
+	return string(ret), nil
+}
+
+func isDirectory(path string) (isDir bool, err error) {
+	var fi fs.FileInfo
+	if fi, err = os.Stat(path); err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
 }
 
 func printJSON(v interface{}) (err error) {

--- a/pkg/api/v1/api.go
+++ b/pkg/api/v1/api.go
@@ -5,7 +5,10 @@ describe and document the API for external users.
 */
 package api
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 //===========================================================================
 // Service Interface
@@ -13,7 +16,9 @@ import "time"
 
 // Service defines the API, which is implemented by the v1 client.
 type Service interface {
-	Status() (*StatusReply, error)
+	Status(ctx context.Context) (out *StatusReply, err error)
+	CreateSecret(ctx context.Context, in *CreateSecretRequest) (out *CreateSecretReply, err error)
+	FetchSecret(ctx context.Context, token string, in *FetchSecretRequest) (out *FetchSecretReply, err error)
 }
 
 //===========================================================================
@@ -32,4 +37,32 @@ type StatusReply struct {
 	Timestamp time.Time `json:"timestamp,omitempty"`
 	Version   string    `json:"version,omitempty"`
 	Error     string    `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
+//===========================================================================
+// Secret REST API
+//===========================================================================
+
+type CreateSecretRequest struct {
+	Secret   string   `json:"secret" binding:"required"` // the secret can be a string of any length or base64 encoded data
+	Password string   `json:"password,omitempty"`        // a password that must be used to retrieve the secret
+	Lifetime Duration `json:"lifetime,omitempty"`        // how long the secret will last before being deleted
+	Filename string   `json:"filename,omitempty"`        // if the secret is a filename, the name of the file
+	IsBase64 bool     `json:"is_base64"`                 // if the secret is base64 encoded or not
+}
+
+type CreateSecretReply struct {
+	Token   string    `json:"token"`   // the token used to retrieve the secret (so the URL doesn't have to be parsed)
+	Expires time.Time `json:"expires"` // the timestamp when the secret will have expired
+}
+
+type FetchSecretRequest struct {
+	Password string `json:"password,omitempty"` // the password to retrieve the secret, if required
+}
+
+type FetchSecretReply struct {
+	Secret   string    `json:"secret"`             // the secret retrieved by the database, which is now deleted
+	Filename string    `json:"filename,omitempty"` // the name of the file used to create the secret to save as a file
+	IsBase64 bool      `json:"is_base64"`          // if the secret is base64 encoded data
+	Created  time.Time `json:"created"`            // the timestamp the secret was created
 }

--- a/pkg/api/v1/client.go
+++ b/pkg/api/v1/client.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -30,15 +33,82 @@ type api struct {
 	client   *http.Client
 }
 
-func (s api) Status() (_ *StatusReply, err error) {
-	// Resolve the URL reference
-	u := s.endpoint.ResolveReference(&url.URL{Path: "/v1/status"})
+// NewRequest creates an http.Request with the specified context and method, resolving
+// the path to the root endpoint of the API (e.g. /v1) and serializes the data to JSON.
+// This method also sets the default headers of all whisper client requests.
+func (s api) NewRequest(ctx context.Context, method, path string, data interface{}) (req *http.Request, err error) {
+	// Resolve the URL reference from the path
+	endpoint := s.endpoint.ResolveReference(&url.URL{Path: path})
 
+	var body io.ReadWriter
+	if data != nil {
+		body = &bytes.Buffer{}
+		if err = json.NewEncoder(body).Encode(data); err != nil {
+			return nil, fmt.Errorf("could not serialize request data: %s", err)
+		}
+	} else {
+		body = nil
+	}
+
+	// Create the http request
+	if req, err = http.NewRequestWithContext(ctx, method, endpoint.String(), body); err != nil {
+		return nil, fmt.Errorf("could not create request: %s", err)
+	}
+
+	// Set the headers on the request
+	req.Header.Add("User-Agent", "Whisper/1.0")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept-Language", "en-US,en")
+	req.Header.Add("Accept-Encoding", "gzip, deflate, br")
+	req.Header.Add("Content-Type", "application/json")
+
+	return req, nil
+}
+
+// Do executes an http request against the server, performs error checking, and
+// deserializes the response data into the specified struct if requested.
+func (s api) Do(req *http.Request, data interface{}, checkStatus bool) (rep *http.Response, err error) {
+	if rep, err = s.client.Do(req); err != nil {
+		return rep, fmt.Errorf("could not execute request: %s", err)
+	}
+	defer rep.Body.Close()
+
+	// Detect errors if they've occurred
+	if checkStatus {
+		if rep.StatusCode < 200 || rep.StatusCode >= 300 {
+			return rep, fmt.Errorf("[%d] %s", rep.StatusCode, rep.Status)
+		}
+	}
+
+	// Check the content type to ensure data deserialization is possible
+	if ct := rep.Header.Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		return rep, fmt.Errorf("unexpected content type: %q", ct)
+	}
+
+	// Deserialize the JSON data from the body
+	if data != nil && rep.StatusCode >= 200 && rep.StatusCode < 300 {
+		if err = json.NewDecoder(rep.Body).Decode(data); err != nil {
+			return nil, fmt.Errorf("could not deserialize response data: %s", err)
+		}
+	}
+
+	return rep, nil
+}
+
+func (s api) Status(ctx context.Context) (out *StatusReply, err error) {
 	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/status", nil); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	// NOTE: cannot use s.Do because we want to parse 503 Unavailable errors
 	var rep *http.Response
-	if rep, err = s.client.Get(u.String()); err != nil {
+	if rep, err = s.client.Do(req); err != nil {
 		return nil, fmt.Errorf("could not execute request: %s", err)
 	}
+	defer rep.Body.Close()
 
 	// Detect other errors
 	if rep.StatusCode != http.StatusOK && rep.StatusCode != http.StatusServiceUnavailable {
@@ -46,9 +116,41 @@ func (s api) Status() (_ *StatusReply, err error) {
 	}
 
 	// Deserialize the JSON data from the response
-	status := &StatusReply{}
-	if err = json.NewDecoder(rep.Body).Decode(status); err != nil {
+	out = &StatusReply{}
+	if err = json.NewDecoder(rep.Body).Decode(out); err != nil {
 		return nil, fmt.Errorf("could not deserialize StatusReply: %s", err)
 	}
-	return status, nil
+	return out, nil
+}
+
+func (s api) CreateSecret(ctx context.Context, in *CreateSecretRequest) (out *CreateSecretReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/secrets", in); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &CreateSecretReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (s api) FetchSecret(ctx context.Context, token string, in *FetchSecretRequest) (out *FetchSecretReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/secrets/%s", token), in); err != nil {
+		return nil, err
+	}
+
+	// Execute the request and get a response
+	out = &FetchSecretReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }

--- a/pkg/api/v1/duration.go
+++ b/pkg/api/v1/duration.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Duration implements a JSON serializable time.Duration.
+type Duration time.Duration
+
+// MarshalJSON the duration as a string, e.g. 10s
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON from either a float64 or a string
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		tmp, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(tmp)
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/pkg/secrets.go
+++ b/pkg/secrets.go
@@ -1,0 +1,114 @@
+package whisper
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	v1 "github.com/rotationalio/whisper/pkg/api/v1"
+	"github.com/rs/zerolog/log"
+)
+
+// DefaultSecretLifetime is one week after which the secret will be deleted.
+const DefaultSecretLifetime = time.Hour * 24 * 7
+
+var tmpSecretsStore = make(map[string]v1.CreateSecretRequest)
+
+// CreateSecret handles an incoming CreateSecretRequest and attempts to create a new
+// secret that will only be displayed when the correct link is retrieved.
+func (s *Server) CreateSecret(c *gin.Context) {
+	// Parse incoming JSON data from the client request
+	var req v1.CreateSecretRequest
+	if err := c.ShouldBind(&req); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse("invalid create secret request"))
+		return
+	}
+
+	// Create the reply to return to the User
+	var err error
+	rep := &v1.CreateSecretReply{}
+
+	// Make a random URL to store the secret in
+	if rep.Token, err = GenerateUniqueURL(); err != nil {
+		log.Error().Err(err).Msg("could not generate unique token for secret")
+		c.JSON(http.StatusInternalServerError, ErrorResponse(err))
+		return
+	}
+
+	// Compute the expiration time from the request
+	if req.Lifetime == v1.Duration(0) {
+		fmt.Println(req.Lifetime)
+		rep.Expires = time.Now().Add(DefaultSecretLifetime)
+	} else {
+		rep.Expires = time.Now().Add(time.Duration(req.Lifetime))
+	}
+
+	// Store the password in the database
+	tmpSecretsStore[rep.Token] = req
+
+	// Return success
+	c.JSON(http.StatusCreated, rep)
+}
+
+// FetchSecret handles an incoming FetchSecretRequest and attempts to retrieve the
+// secret from the database and return it to the user. This function also handles the
+// password and ensures that a 404 is returned to obfuscate the existence of the secret
+// on bad requests.
+// TODO: handle passwords (should this also be post?)
+// TODO: add created timestamp
+func (s *Server) FetchSecret(c *gin.Context) {
+	token := c.Param("token")
+	req, ok := tmpSecretsStore[token]
+	if !ok {
+		c.JSON(http.StatusNotFound, ErrorResponse("secret not found"))
+		return
+	}
+
+	rep := v1.FetchSecretReply{
+		Secret:   req.Secret,
+		Filename: req.Filename,
+		IsBase64: req.IsBase64,
+	}
+	c.JSON(http.StatusOK, rep)
+}
+
+const (
+	generateUniqueLength   = 32
+	generateUniqueAttempts = 8
+)
+
+// GenerateUniqueURL is a helper function that uses crypto/rand to create a random
+// URL-safe string and determines if it is in the database or not. If it finds a
+// collision it attempts to find a unique string for a fixed number of attempts before
+// quitting.
+func GenerateUniqueURL() (token string, err error) {
+	for i := 0; i < generateUniqueAttempts; i++ {
+		// Create a random array of bytes
+		buf := make([]byte, generateUniqueLength)
+		if _, err = rand.Read(buf); err != nil {
+			return "", err
+		}
+
+		// Convert random array into URL safe base64 encoded string
+		token := base64.RawURLEncoding.EncodeToString(buf)
+
+		// Check if the token exists already in the database
+		if _, ok := tmpSecretsStore[token]; !ok {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("could not generate unique URL after %d attempts", generateUniqueAttempts)
+}
+
+// Check that a cryptographically secure PRNG is available.
+func checkAvailablePRNG() (err error) {
+	buf := make([]byte, 1)
+	if _, err = io.ReadFull(rand.Reader, buf); err != nil {
+		return fmt.Errorf("crypto/rand is unavailable: failed with %#v", err)
+	}
+	return nil
+}

--- a/pkg/secrets_test.go
+++ b/pkg/secrets_test.go
@@ -1,0 +1,25 @@
+package whisper_test
+
+import (
+	"testing"
+
+	. "github.com/rotationalio/whisper/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateUniqueURL(t *testing.T) {
+	tokens := make(map[string]struct{})
+	for i := 0; i < 48; i++ {
+		// Generate token
+		token, err := GenerateUniqueURL()
+		require.NoError(t, err)
+		require.Len(t, token, 44)
+
+		// Make sure token is unique
+		_, ok := tokens[token]
+		require.False(t, ok)
+
+		// Add token to unique set
+		tokens[token] = struct{}{}
+	}
+}

--- a/pkg/secrets_test.go
+++ b/pkg/secrets_test.go
@@ -13,7 +13,7 @@ func TestGenerateUniqueURL(t *testing.T) {
 		// Generate token
 		token, err := GenerateUniqueURL()
 		require.NoError(t, err)
-		require.Len(t, token, 44)
+		require.Len(t, token, 43)
 
 		// Make sure token is unique
 		_, ok := tokens[token]


### PR DESCRIPTION
This PR implements API endpoints for creating secrets by POST to `/v1/secrets` and GET (soon also POST) to `/v1/secrets/:token`. The PR primarily considers the JSON data structures for interacting with the server and the basic logic of secret creation, though no backend database is currently implemented. 

This PR also deeply considers interactions with the API on the command line and provides a lot of options for interaction that should communicate what happens on the front end. 

Questions:

1. How do we supply the password on fetch? Should it be in the headers or as a POST in the JSON body or as a query param or some combination of all of the above? REST semantics say this should be a GET to the detail endpoint and the password should be in the header, but we could make this more RPC like
3. Do we want the ability to copy the secret on the clipboard from the command line?
4. Should we only allow the secret to be fetched once, or should we allow multiple fetches before the expiration up to some limit set by the create API. 

TODO:

- [ ] Password handling per the answer to the question above 
- [ ] Implement database storage for the secrets
- [ ] Implement aging out the secrets