### PR TITLE
Complete API logic and accesses limit

### DIFF
--- a/pkg/api/v1/api.go
+++ b/pkg/api/v1/api.go
@@ -18,7 +18,8 @@ import (
 type Service interface {
 	Status(ctx context.Context) (out *StatusReply, err error)
 	CreateSecret(ctx context.Context, in *CreateSecretRequest) (out *CreateSecretReply, err error)
-	FetchSecret(ctx context.Context, token string, in *FetchSecretRequest) (out *FetchSecretReply, err error)
+	FetchSecret(ctx context.Context, token, password string) (out *FetchSecretReply, err error)
+	DestroySecret(ctx context.Context, token, password string) (out *DestroySecretReply, err error)
 }
 
 //===========================================================================
@@ -46,6 +47,7 @@ type StatusReply struct {
 type CreateSecretRequest struct {
 	Secret   string   `json:"secret" binding:"required"` // the secret can be a string of any length or base64 encoded data
 	Password string   `json:"password,omitempty"`        // a password that must be used to retrieve the secret
+	Accesses int      `json:"accesses,omitempty"`        // specify the number of times the secret can be accessed; default is 1, if negative, can be accessed until the secret expires
 	Lifetime Duration `json:"lifetime,omitempty"`        // how long the secret will last before being deleted
 	Filename string   `json:"filename,omitempty"`        // if the secret is a filename, the name of the file
 	IsBase64 bool     `json:"is_base64"`                 // if the secret is base64 encoded or not
@@ -56,13 +58,14 @@ type CreateSecretReply struct {
 	Expires time.Time `json:"expires"` // the timestamp when the secret will have expired
 }
 
-type FetchSecretRequest struct {
-	Password string `json:"password,omitempty"` // the password to retrieve the secret, if required
-}
-
 type FetchSecretReply struct {
 	Secret   string    `json:"secret"`             // the secret retrieved by the database, which is now deleted
 	Filename string    `json:"filename,omitempty"` // the name of the file used to create the secret to save as a file
 	IsBase64 bool      `json:"is_base64"`          // if the secret is base64 encoded data
 	Created  time.Time `json:"created"`            // the timestamp the secret was created
+	Accesses int       `json:"accesses"`           // the number of times the secret has been accessed
+}
+
+type DestroySecretReply struct {
+	Destroyed bool `json:"destroyed"` // if the secret was destroyed or not
 }

--- a/pkg/api/v1/client.go
+++ b/pkg/api/v1/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -139,15 +140,41 @@ func (s api) CreateSecret(ctx context.Context, in *CreateSecretRequest) (out *Cr
 	return out, nil
 }
 
-func (s api) FetchSecret(ctx context.Context, token string, in *FetchSecretRequest) (out *FetchSecretReply, err error) {
+func (s api) FetchSecret(ctx context.Context, token, password string) (out *FetchSecretReply, err error) {
 	//  Make the HTTP request
 	var req *http.Request
-	if req, err = s.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/secrets/%s", token), in); err != nil {
+	if req, err = s.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/secrets/%s", token), nil); err != nil {
 		return nil, err
+	}
+
+	// If a password is supplied set the Authorization header
+	if password != "" {
+		req.Header.Add("Authorization", "Bearer "+base64.URLEncoding.EncodeToString([]byte(password)))
 	}
 
 	// Execute the request and get a response
 	out = &FetchSecretReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func (s api) DestroySecret(ctx context.Context, token, password string) (out *DestroySecretReply, err error) {
+	//  Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("/v1/secrets/%s", token), nil); err != nil {
+		return nil, err
+	}
+
+	// If a password is supplied set the Authorization header
+	if password != "" {
+		req.Header.Add("Authorization", "Bearer "+base64.URLEncoding.EncodeToString([]byte(password)))
+	}
+
+	// Execute the request and get a response
+	out = &DestroySecretReply{}
 	if _, err = s.Do(req, out, true); err != nil {
 		return nil, err
 	}

--- a/pkg/models.go
+++ b/pkg/models.go
@@ -1,0 +1,38 @@
+package whisper
+
+import "time"
+
+// SecretMetadata stores sidechannel information related to the secret but not the
+// secret itself. This data allows the whipser service to manage passwords, the number
+// of accesses, and the expiration of the secret without having to retrieve the secret
+// directly, creating a possible vulnerability.
+type SecretMetadata struct {
+	Password     string    `json:"password,omitempty"` // the argon2 hashed password for comparision
+	Filename     string    `json:"filename,omitempty"` // if the secret is a file, the name of the file for download
+	IsBase64     bool      `json:"is_base64"`          // if the secret is base64 encoded or not
+	Accesses     int       `json:"accesses"`           // the number of allowed accesses for the secret
+	Retrievals   int       `json:"retrievals"`         // counts the number of times the secret has been accessed
+	Created      time.Time `json:"created"`            // the timestamp the secret was created
+	LastAccessed time.Time `json:"last_accessed"`      // the timestamp that the secret was last accessed
+	Expires      time.Time `json:"expires"`            // the timestamp when the secret will have expired
+}
+
+// Valid returns true if the retrievals is less than the number of allowed accesses and
+// the current time is before the expiration time.
+func (s *SecretMetadata) Valid() bool {
+	if time.Now().After(s.Expires) {
+		return false
+	}
+
+	if s.Accesses > 0 && s.Retrievals >= s.Accesses {
+		return false
+	}
+
+	return true
+}
+
+// Access updates the secret metadata on a fetch or other access to the secret.
+func (s *SecretMetadata) Access() {
+	s.Retrievals++
+	s.LastAccessed = time.Now()
+}

--- a/pkg/secrets.go
+++ b/pkg/secrets.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,10 +15,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// DefaultSecretLifetime is one week after which the secret will be deleted.
+// DefaultSecretLifetime is one week after which the secret will be destroyed.
 const DefaultSecretLifetime = time.Hour * 24 * 7
 
-var tmpSecretsStore = make(map[string]v1.CreateSecretRequest)
+// DefaultSecretAccesses ensures that once the secret is fetched it is destroyed
+const DefaultSecretAccesses = 1
+
+var tmpSecretsStore = make(map[string]string)
+var tmpSecretsMeta = make(map[string]*SecretMetadata)
 
 // CreateSecret handles an incoming CreateSecretRequest and attempts to create a new
 // secret that will only be displayed when the correct link is retrieved.
@@ -28,9 +34,33 @@ func (s *Server) CreateSecret(c *gin.Context) {
 		return
 	}
 
-	// Create the reply to return to the User
+	// Create the secret metadata
+	meta := &SecretMetadata{
+		Password: req.Password, // TODO: argon2 hash the password since there is no reason for us to store raw passwords
+		Filename: req.Filename,
+		IsBase64: req.IsBase64,
+		Created:  time.Now(),
+	}
+
+	// Compute the number of accesses for the secret
+	if req.Accesses == 0 {
+		meta.Accesses = DefaultSecretAccesses
+	} else {
+		meta.Accesses = req.Accesses
+	}
+
+	// Compute the expiration time from the request
+	if req.Lifetime == v1.Duration(0) {
+		meta.Expires = meta.Created.Add(DefaultSecretLifetime)
+	} else {
+		meta.Expires = meta.Created.Add(time.Duration(req.Lifetime))
+	}
+
+	// Create the reply back to the user
 	var err error
-	rep := &v1.CreateSecretReply{}
+	rep := &v1.CreateSecretReply{
+		Expires: meta.Expires,
+	}
 
 	// Make a random URL to store the secret in
 	if rep.Token, err = GenerateUniqueURL(); err != nil {
@@ -39,41 +69,119 @@ func (s *Server) CreateSecret(c *gin.Context) {
 		return
 	}
 
-	// Compute the expiration time from the request
-	if req.Lifetime == v1.Duration(0) {
-		fmt.Println(req.Lifetime)
-		rep.Expires = time.Now().Add(DefaultSecretLifetime)
-	} else {
-		rep.Expires = time.Now().Add(time.Duration(req.Lifetime))
-	}
-
 	// Store the password in the database
-	tmpSecretsStore[rep.Token] = req
+	tmpSecretsStore[rep.Token] = req.Secret
+	tmpSecretsMeta[rep.Token] = meta
 
 	// Return success
 	c.JSON(http.StatusCreated, rep)
 }
 
-// FetchSecret handles an incoming FetchSecretRequest and attempts to retrieve the
+// FetchSecret handles an incoming fetch secret request and attempts to retrieve the
 // secret from the database and return it to the user. This function also handles the
 // password and ensures that a 404 is returned to obfuscate the existence of the secret
 // on bad requests.
-// TODO: handle passwords (should this also be post?)
-// TODO: add created timestamp
+// TODO: handle passwords with argon2
 func (s *Server) FetchSecret(c *gin.Context) {
+	// Fetch the meta with the token
 	token := c.Param("token")
-	req, ok := tmpSecretsStore[token]
+	meta, ok := tmpSecretsMeta[token]
 	if !ok {
 		c.JSON(http.StatusNotFound, ErrorResponse("secret not found"))
 		return
 	}
 
-	rep := v1.FetchSecretReply{
-		Secret:   req.Secret,
-		Filename: req.Filename,
-		IsBase64: req.IsBase64,
+	// Check the secret is valid prior to returning a response (in case a sidechannel
+	// retrieval or race condition failed to destroy the password).
+	if !meta.Valid() {
+		log.Warn().Msg("race condition or invalid secret metadata fetched, destroying")
+		delete(tmpSecretsMeta, token)
+		delete(tmpSecretsStore, token)
+		c.JSON(http.StatusNotFound, ErrorResponse("secret not found"))
+		return
 	}
+
+	// Check the password if it has been posted
+	// TODO: perform argon2 password checking
+	if meta.Password != "" {
+		// A password is required as an Authorization: Bearer <token> header where the
+		// token is the base64 encoded password. Basic auth does not apply here since
+		// there is no username associated with the secret.
+		password := ParseBearerToken(c.GetHeader("Authorization"))
+		if password == "" || password != meta.Password {
+			c.JSON(http.StatusUnauthorized, ErrorResponse("password required for secret"))
+			return
+		}
+	}
+
+	// Update metadata with the access info
+	meta.Access()
+
+	// Create the secret reply
+	rep := v1.FetchSecretReply{
+		Filename: meta.Filename,
+		IsBase64: meta.IsBase64,
+		Created:  meta.Created,
+		Accesses: meta.Retrievals,
+	}
+
+	// Fetch the secret with the token
+	if rep.Secret, ok = tmpSecretsStore[token]; !ok {
+		c.JSON(http.StatusInternalServerError, ErrorResponse("unhandled secret store error"))
+		return
+	}
+
+	// Cleanup if necessary
+	if !meta.Valid() {
+		delete(tmpSecretsMeta, token)
+		delete(tmpSecretsStore, token)
+	}
+
+	// Return the successful reply
 	c.JSON(http.StatusOK, rep)
+}
+
+// DestroySecret handles an incoming destroy secret request and attempts to delete the
+// secret from the database. This RPC is password protected in the same way fetch is.
+// TODO: handle passwords with argon2
+func (s *Server) DestroySecret(c *gin.Context) {
+	// Fetch the meta with the token
+	token := c.Param("token")
+	meta, ok := tmpSecretsMeta[token]
+	if !ok {
+		c.JSON(http.StatusNotFound, ErrorResponse("secret not found"))
+		return
+	}
+
+	// Check the secret is valid prior to returning a response (in case a sidechannel
+	// retrieval or race condition failed to destroy the password).
+	if !meta.Valid() {
+		log.Warn().Msg("race condition or invalid secret metadata fetched, destroying")
+		delete(tmpSecretsMeta, token)
+		delete(tmpSecretsStore, token)
+		c.JSON(http.StatusNotFound, ErrorResponse("secret not found"))
+		return
+	}
+
+	// Check the password if it has been posted
+	// TODO: perform argon2 password checking
+	if meta.Password != "" {
+		// A password is required as an Authorization: Bearer <token> header where the
+		// token is the base64 encoded password. Basic auth does not apply here since
+		// there is no username associated with the secret.
+		password := ParseBearerToken(c.GetHeader("Authorization"))
+		if password == "" || password != meta.Password {
+			c.JSON(http.StatusUnauthorized, ErrorResponse("password required for secret"))
+			return
+		}
+	}
+
+	// Delete the secret from the database
+	delete(tmpSecretsMeta, token)
+	delete(tmpSecretsStore, token)
+
+	// Return the successful reply
+	c.JSON(http.StatusOK, &v1.DestroySecretReply{Destroyed: true})
 }
 
 const (
@@ -111,4 +219,22 @@ func checkAvailablePRNG() (err error) {
 		return fmt.Errorf("crypto/rand is unavailable: failed with %#v", err)
 	}
 	return nil
+}
+
+var bearerRegex = regexp.MustCompile(`^(?i)Bearer\s+([A-Za-z0-9=+/_-]+)$`)
+
+// ParseBearerToken parses an Authorization: Bearer <token> header such that the token
+// is the base64 encoded password. Basic auth not used here since there is no user.
+func ParseBearerToken(header string) string {
+	header = strings.TrimSpace(header)
+	if header != "" && bearerRegex.MatchString(header) {
+		groups := bearerRegex.FindStringSubmatch(header)
+		token, err := base64.URLEncoding.DecodeString(groups[1])
+		if err != nil {
+			log.Warn().Err(err).Msg("could not base64 decode Authorization header")
+			return ""
+		}
+		return string(token)
+	}
+	return ""
 }

--- a/pkg/secrets_test.go
+++ b/pkg/secrets_test.go
@@ -1,6 +1,7 @@
 package whisper_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	. "github.com/rotationalio/whisper/pkg"
@@ -21,5 +22,27 @@ func TestGenerateUniqueURL(t *testing.T) {
 
 		// Add token to unique set
 		tokens[token] = struct{}{}
+	}
+}
+
+func TestParseBearerToken(t *testing.T) {
+	password := base64.URLEncoding.EncodeToString([]byte("supersecretsquirrel"))
+	tt := []struct {
+		header   string
+		expected string
+	}{
+		// Success cases
+		{"Bearer " + password, "supersecretsquirrel"},
+		{"bearer " + password, "supersecretsquirrel"},
+		{"   Bearer    " + password, "supersecretsquirrel"},
+
+		// Failure cases
+		{password, ""},                        // No bearer token
+		{"Bearer supersecretsquirrel", ""},    // Not base64 encoded
+		{"weird foo string with nothing", ""}, // No bearer realm
+	}
+
+	for _, tc := range tt {
+		require.Equal(t, tc.expected, ParseBearerToken(tc.header))
 	}
 }

--- a/pkg/whisper.go
+++ b/pkg/whisper.go
@@ -152,6 +152,7 @@ func (s *Server) setupRoutes() (err error) {
 	v1.GET("/status", s.Status)
 	v1.POST("/secrets", s.CreateSecret)
 	v1.GET("/secrets/:token", s.FetchSecret)
+	v1.DELETE("/secrets/:token", s.DestroySecret)
 
 	// NotFound and NotAllowed requests
 	s.router.NoRoute(NotFound)


### PR DESCRIPTION
Completes the API logic by storing secret metadata as its own independent data structure, adds a destroy endpoint, and implements basic password handling and password validation and secret cleanup. 

Also adds an accesses limit which is by default 1 (one time access) but can be specified as more by the user or if negative, unlimited accesses until the secret expires.