### PR TITLE
Adds Destroyed boolean to fetch

### DIFF
--- a/pkg/api/v1/api.go
+++ b/pkg/api/v1/api.go
@@ -59,11 +59,12 @@ type CreateSecretReply struct {
 }
 
 type FetchSecretReply struct {
-	Secret   string    `json:"secret"`             // the secret retrieved by the database, which is now deleted
-	Filename string    `json:"filename,omitempty"` // the name of the file used to create the secret to save as a file
-	IsBase64 bool      `json:"is_base64"`          // if the secret is base64 encoded data
-	Created  time.Time `json:"created"`            // the timestamp the secret was created
-	Accesses int       `json:"accesses"`           // the number of times the secret has been accessed
+	Secret    string    `json:"secret"`             // the secret retrieved by the database, which is now deleted
+	Filename  string    `json:"filename,omitempty"` // the name of the file used to create the secret to save as a file
+	IsBase64  bool      `json:"is_base64"`          // if the secret is base64 encoded data
+	Created   time.Time `json:"created"`            // the timestamp the secret was created
+	Accesses  int       `json:"accesses"`           // the number of times the secret has been accessed
+	Destroyed bool      `json:"destroyed"`          // if the secret was destroyed after the fetch
 }
 
 type DestroySecretReply struct {

--- a/pkg/secrets.go
+++ b/pkg/secrets.go
@@ -106,7 +106,7 @@ func (s *Server) FetchSecret(c *gin.Context) {
 	log.Debug().Bool("authorization", password != "").Msg("beginning fetch")
 
 	// Attempt to retrieve the secret from the database
-	secret, err := meta.Fetch(context.TODO(), password)
+	secret, destroyed, err := meta.Fetch(context.TODO(), password)
 	if err != nil {
 		switch err {
 		case ErrSecretNotFound:
@@ -122,11 +122,12 @@ func (s *Server) FetchSecret(c *gin.Context) {
 
 	// Create the secret reply
 	rep := v1.FetchSecretReply{
-		Secret:   secret,
-		Filename: meta.Filename,
-		IsBase64: meta.IsBase64,
-		Created:  meta.Created,
-		Accesses: meta.Retrievals,
+		Secret:    secret,
+		Filename:  meta.Filename,
+		IsBase64:  meta.IsBase64,
+		Created:   meta.Created,
+		Accesses:  meta.Retrievals,
+		Destroyed: destroyed,
 	}
 
 	// Return the successful reply


### PR DESCRIPTION
If the secret was destroyed during the fetch, it is returned with the
API response so that the front-end can determine if further operations
are allowed such as deleting the secret on demand.