### PR TITLE
Add Authorization header to CORS allowed header policy

### DIFF
--- a/pkg/whisper.go
+++ b/pkg/whisper.go
@@ -75,7 +75,7 @@ func New(conf config.Config) (s *Server, err error) {
 	s.router.Use(cors.New(cors.Config{
 		AllowAllOrigins:  true,
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},
-		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type"},
+		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
 	}))


### PR DESCRIPTION
Even though `Access-Control-Allow-Credentials` is true, it seems that axios still needs `Authorization` to explicitly be set in `Access-Control-Allow-Headers`. This PR makes that change and adds a test to help us try to debug CORS issues in the future. 