### PR TITLE
Updates URL handling in the API and UI

### DIFF
--- a/cmd/whisper/main.go
+++ b/cmd/whisper/main.go
@@ -35,7 +35,7 @@ func main() {
 			Aliases: []string{"e", "url", "u"},
 			Usage:   "endpoint to connect to the whisper service on",
 			EnvVars: []string{"WHISPER_ENDPOINT", "WHISPER_URL"},
-			Value:   "https://whisper.rotational.dev",
+			Value:   "https://api.whisper.rotational.dev",
 		},
 	}
 

--- a/containers/web/Dockerfile
+++ b/containers/web/Dockerfile
@@ -8,7 +8,8 @@ COPY web/yarn.lock ./
 RUN yarn
 
 # Set production environment variable for build context
-ARG REACT_APP_API_BASE_URL "https://whisper.rotational.dev/v1"
+ARG REACT_APP_API_BASE_URL "https://api.whisper.rotational.dev/v1"
+ARG REACT_APP_UI_BASE_URL "https://whisper.rotational.dev"
 ARG NODE_ENV "production"
 
 # Build app with browserify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       dockerfile: containers/web/Dockerfile
       args:
         - "REACT_APP_API_BASE_URL=http://localhost:8318/v1"
+        - "REACT_APP_UI_BASE_URL=http://localhost:3000"
         - "NODE_ENV=production"
     image: rotationalio/whisper-ui:local
     restart: "on-failure"

--- a/web/src/utils/utils.ts
+++ b/web/src/utils/utils.ts
@@ -18,11 +18,27 @@ function defaultEndpointPrefix(): string {
 
 	switch (process.env.NODE_ENV) {
 		case "production":
-			return "https://whisper.rotational.dev/v1";
+			return "https://api.whisper.rotational.dev/v1";
+		case "development":
+			return "http://localhost:8318/v1";
+		default:
+			throw new Error("Could not identify the api prefix");
+	}
+}
+
+function defaultAbsoluteURL(): string {
+	const baseURL = process.env.REACT_APP_UI_BASE_URL;
+	if (baseURL) {
+		return baseURL;
+	}
+
+	switch (process.env.NODE_ENV) {
+		case "production":
+			return "https://whisper.rotational.dev";
 		case "development":
 			return "http://localhost:3000";
 		default:
-			throw new Error("Could not identify the api prefix");
+			throw new Error("could not identify the ui absolute url");
 	}
 }
 
@@ -65,9 +81,7 @@ function formatBytes(bytes: number, decimals = 2) {
 }
 
 function generateSecretLink(token: string): string {
-	return process.env.NODE_ENV === "development"
-		? `http://localhost:3000/secret/${token}`
-		: `${defaultEndpointPrefix()}/secret/${token}`;
+	return `${defaultAbsoluteURL()}/secret/${token}`;
 }
 
 function stringToBase64(str: string): string {


### PR DESCRIPTION
To make things simple and to avoid having to have an nginx proxy, I've
simply made the API endpoint https://api.whisper.rotational.dev and the
UI remains at https://whisper.rotational.dev. I've added a new function
defaultAbsoluteURL in the web code to compute the token link and changed
the CLI program to go to the correct API link by default.