### PR TITLE
Deploy Whisper to Cloud Run with GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 on:
   push:
     branches:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,62 @@
+name: Deploy to Cloud Run
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  api_deploy:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/whisper-api
+    steps:
+      - name: Login to Google
+        uses GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_email: ${{ secrets.GCP_EMAIL }}
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker --quiet
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Build Docker Image
+        run: docker build -t $IMAGE_NAME -f containers/api/Dockerfile .
+
+      - name: Push Docker Image
+        run: docker push $IMAGE_NAME
+
+      - name: Deploy Docker Image
+        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME --region us-central1 --platform managed
+
+  web_deploy:
+    name: Deploy API
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/whisper-ui
+    steps:
+      - name: Login to Google
+        uses GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_email: ${{ secrets.GCP_EMAIL }}
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker --quiet
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Build Docker Image
+        run: docker build -t $IMAGE_NAME -f containers/web/Dockerfile .
+
+      - name: Push Docker Image
+        run: docker push $IMAGE_NAME
+
+      - name: Deploy Docker Image
+        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME --region us-central1 --platform managed

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,7 +12,7 @@ jobs:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/whisper-api
     steps:
       - name: Login to Google
-        uses GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
@@ -24,14 +24,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      - name: Get Version Tag
+        uses: actions/checkout@v2
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Build Docker Image
-        run: docker build -t $IMAGE_NAME -f containers/api/Dockerfile .
+        run: docker build -t $IMAGE_NAME:$RELEASE_VERSION -f containers/api/Dockerfile .
 
       - name: Push Docker Image
-        run: docker push $IMAGE_NAME
+        run: docker push $IMAGE_NAME:$RELEASE_VERSION
 
       - name: Deploy Docker Image
-        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME --region us-central1 --platform managed
+        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME:$RELEASE_VERSION --region us-central1 --platform managed
 
   web_deploy:
     name: Deploy API
@@ -40,7 +44,7 @@ jobs:
       IMAGE_NAME: gcr.io/${{ secrets.GCP_PROJECT_ID }}/whisper-ui
     steps:
       - name: Login to Google
-        uses GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_email: ${{ secrets.GCP_EMAIL }}
@@ -52,11 +56,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      - name: Get Version Tag
+        uses: actions/checkout@v2
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Build Docker Image
-        run: docker build -t $IMAGE_NAME -f containers/web/Dockerfile .
+        run: docker build -t $IMAGE_NAME:$RELEASE_VERSION -f containers/web/Dockerfile .
 
       - name: Push Docker Image
-        run: docker push $IMAGE_NAME
+        run: docker push $IMAGE_NAME:$RELEASE_VERSION
 
       - name: Deploy Docker Image
-        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME --region us-central1 --platform managed
+        run: gcloud run deploy ${{ secrets. GCP_PROJECT_ID }} --image $IMAGE_NAME:$RELEASE_VERSION --region us-central1 --platform managed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: CD
+name: Publish Release
 on:
   push:
     tags:


### PR DESCRIPTION
Some setup is required on Google and GitHub but it seems that the
simplest way to deploy both the React UI and the API is to use GitHub
actions to build gcr.io images and push them to Google, then run gcloud
to deploy to Cloud Run. This will stop us from using Google Build, but
hopefully that will make things simpler.