### PR TITLE
Restrict Whisper CORS policy by configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,13 +19,14 @@ import (
 // Config uses envconfig to load required settings from the environment and validate
 // them in preparation for running the whisper service.
 type Config struct {
-	Maintenance bool            `split_words:"true" default:"false"`
-	Mode        string          `split_words:"true" default:"debug"`
-	BindAddr    string          `split_words:"true" required:"false"`
-	LogLevel    LogLevelDecoder `split_words:"true" default:"info"`
-	ConsoleLog  bool            `split_words:"true" default:"false"`
-	Google      GoogleConfig
-	processed   bool
+	Maintenance  bool            `split_words:"true" default:"false"`
+	Mode         string          `split_words:"true" default:"debug"`
+	BindAddr     string          `split_words:"true" required:"false"`
+	LogLevel     LogLevelDecoder `split_words:"true" default:"info"`
+	ConsoleLog   bool            `split_words:"true" default:"false"`
+	AllowOrigins []string        `split_words:"true" default:"https://whisper.rotational.dev"`
+	Google       GoogleConfig
+	processed    bool
 }
 
 type GoogleConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,7 @@ var testEnv = map[string]string{
 	"WHISPER_BIND_ADDR":              ":443",
 	"WHISPER_LOG_LEVEL":              "debug",
 	"WHISPER_CONSOLE_LOG":            "true",
+	"WHISPER_ALLOW_ORIGINS":          "https://whisper.rotational.dev,https://whisper.rotational.io",
 	"GOOGLE_APPLICATION_CREDENTIALS": "fixtures/whisper-sa.json",
 	"GOOGLE_PROJECT_NAME":            "test-project",
 	"WHISPER_GOOGLE_TESTING":         "true",
@@ -43,6 +44,7 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, gin.ReleaseMode, conf.Mode)
 	require.Equal(t, testEnv["WHISPER_BIND_ADDR"], conf.BindAddr)
 	require.Equal(t, zerolog.DebugLevel, conf.GetLogLevel())
+	require.Len(t, conf.AllowOrigins, 2)
 	require.Equal(t, testEnv["GOOGLE_APPLICATION_CREDENTIALS"], conf.Google.Credentials)
 	require.Equal(t, testEnv["GOOGLE_PROJECT_NAME"], conf.Google.Project)
 	require.True(t, conf.Google.Testing)

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -11,7 +11,7 @@ import (
 const (
 	VersionMajor         = 1
 	VersionMinor         = 1
-	VersionPatch         = 0
+	VersionPatch         = 1
 	VersionReleaseLevel  = ""
 	VersionReleaseNumber = 0
 )

--- a/pkg/whisper.go
+++ b/pkg/whisper.go
@@ -71,9 +71,8 @@ func New(conf config.Config) (s *Server, err error) {
 	s.router.Use(gin.Recovery())
 
 	// Add CORS configuration
-	// TODO: configure origins from the environment rather than hard-coding
 	s.router.Use(cors.New(cors.Config{
-		AllowAllOrigins:  true,
+		AllowOrigins:     conf.AllowOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 		AllowCredentials: true,

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE_URL=https://api.whisper.rotational.dev/v1
+REACT_APP_API_BASE_URL=http://localhost:8318/v1


### PR DESCRIPTION
Previously our access control policy was allow any - however to make
things a bit tidier, we've implmented an access control policy that can
be configured by an environment variable. Note that only browsers
respect CORS policies, this doesn't affect the CLI or scripts that may
try to interact with the API.